### PR TITLE
Erlang server generation: fix dialyzer warnings; fix min and max issue

### DIFF
--- a/modules/swagger-codegen/src/main/resources/erlang-server/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/api.mustache
@@ -4,6 +4,8 @@
 -export([request_param_info/2]).
 -export([populate_request/3]).
 -export([validate_response/4]).
+%% exported to silence swagger complains
+-export([get_value/3, validate_response_body/4]).
 
 -type operation_id() :: atom().
 -type request_param() :: atom().
@@ -212,7 +214,7 @@ validate(Rule = {enum, Values}, Name, Value, _ValidatorState) ->
     end;
 
 validate(Rule = {max, Max}, Name, Value, _ValidatorState) ->
-    case Value >= Max of
+    case Value =< Max of
         true -> ok;
         false -> validation_error(Rule, Name)
     end;
@@ -224,7 +226,7 @@ validate(Rule = {exclusive_max, ExclusiveMax}, Name, Value, _ValidatorState) ->
     end;
 
 validate(Rule = {min, Min}, Name, Value, _ValidatorState) ->
-    case Value =< Min of
+    case Value >= Min of
         true -> ok;
         false -> validation_error(Rule, Name)
     end;
@@ -290,6 +292,8 @@ validation_error(ViolatedRule, Name) ->
 validation_error(ViolatedRule, Name, Info) ->
     throw({wrong_param, Name, ViolatedRule, Info}).
 
+-spec get_value(body | qs_val | header | binding, Name :: any(), Req0 :: cowboy_req:req()) ->
+    {Value :: any(), Req :: cowboy_req:req()}.
 get_value(body, _Name, Req0) ->
     {ok, Body, Req} = cowboy_req:body(Req0),
     Value = prepare_body(Body),

--- a/modules/swagger-codegen/src/main/resources/erlang-server/auth.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/auth.mustache
@@ -24,8 +24,12 @@ authorize_api_key(LogicHandler, OperationID, From, KeyParam, Req0) ->
                 ApiKey
             ),
             case Result of
+              {{#authMethods}}
+                {{#isApiKey}}
                 {true, Context}  ->
                     {true, Context, Req};
+                {{/isApiKey}}
+              {{/authMethods}}
                 false ->
                     AuthHeader = <<"">>,
                     {false, AuthHeader, Req}

--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
@@ -94,13 +94,15 @@ is_authorized(
     end;
   {{/isApiKey}}
 {{/authMethods}}
+{{/operation}}{{/operations}}
 {{^authMethods}}
 is_authorized(Req, State) ->
-    {true, Req, State};
+    {true, Req, State}.
 {{/authMethods}}
-{{/operation}}{{/operations}}
+{{#authMethods}}
 is_authorized(Req, State) ->
     {{false, <<"">>}, Req, State}.
+{{/authMethods}}
 
 -spec content_types_accepted(Req :: cowboy_req:req(), State :: state()) ->
     {

--- a/modules/swagger-codegen/src/main/resources/erlang-server/logic_handler.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/logic_handler.mustache
@@ -1,11 +1,7 @@
 -module({{packageName}}_logic_handler).
 
 -export([handle_request/4]).
-{{#authMethods}}
-    {{#isApiKey}}
 -export([authorize_api_key/3]).
-    {{/isApiKey}}
-{{/authMethods}}
 -type context() :: #{binary() => any()}.
 -type handler_response() ::{
     Status :: cowboy:http_status(),
@@ -47,4 +43,10 @@ handle_request(Handler, OperationID, Req, Context) ->
 authorize_api_key(Handler, OperationID, ApiKey) ->
     Handler:authorize_api_key(OperationID, ApiKey).
     {{/isApiKey}}
+{{/authMethods}}
+{{^authMethods}}
+-spec authorize_api_key(Handler :: atom(), OperationID :: {{packageName}}_api:operation_id(), ApiKey :: binary()) ->
+    Result :: false.
+authorize_api_key(_Handler, _OperationID, _ApiKey) ->
+    false.
 {{/authMethods}}

--- a/modules/swagger-codegen/src/main/resources/erlang-server/server.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/server.mustache
@@ -9,6 +9,7 @@
 -spec child_spec( ID :: any(), #{
     ip            => inet:ip_address(),
     port          => inet:port_number(),
+    logic_handler => module(),
     net_opts      => []
 }) -> supervisor:child_spec().
 

--- a/samples/server/petstore/erlang-server/src/swagger_api.erl
+++ b/samples/server/petstore/erlang-server/src/swagger_api.erl
@@ -4,6 +4,8 @@
 -export([request_param_info/2]).
 -export([populate_request/3]).
 -export([validate_response/4]).
+%% exported to silence swagger complains
+-export([get_value/3, validate_response_body/4]).
 
 -type operation_id() :: atom().
 -type request_param() :: atom().
@@ -599,7 +601,7 @@ validate(Rule = {enum, Values}, Name, Value, _ValidatorState) ->
     end;
 
 validate(Rule = {max, Max}, Name, Value, _ValidatorState) ->
-    case Value >= Max of
+    case Value =< Max of
         true -> ok;
         false -> validation_error(Rule, Name)
     end;
@@ -611,7 +613,7 @@ validate(Rule = {exclusive_max, ExclusiveMax}, Name, Value, _ValidatorState) ->
     end;
 
 validate(Rule = {min, Min}, Name, Value, _ValidatorState) ->
-    case Value =< Min of
+    case Value >= Min of
         true -> ok;
         false -> validation_error(Rule, Name)
     end;
@@ -677,6 +679,8 @@ validation_error(ViolatedRule, Name) ->
 validation_error(ViolatedRule, Name, Info) ->
     throw({wrong_param, Name, ViolatedRule, Info}).
 
+-spec get_value(body | qs_val | header | binding, Name :: any(), Req0 :: cowboy_req:req()) ->
+    {Value :: any(), Req :: cowboy_req:req()}.
 get_value(body, _Name, Req0) ->
     {ok, Body, Req} = cowboy_req:body(Req0),
     Value = prepare_body(Body),

--- a/samples/server/petstore/erlang-server/src/swagger_pet_handler.erl
+++ b/samples/server/petstore/erlang-server/src/swagger_pet_handler.erl
@@ -204,7 +204,7 @@ is_authorized(
 ) ->
 
 is_authorized(Req, State) ->
-    {{false, <<"">>}, Req, State}.
+    {true, Req, State}.
 
 -spec content_types_accepted(Req :: cowboy_req:req(), State :: state()) ->
     {

--- a/samples/server/petstore/erlang-server/src/swagger_server.erl
+++ b/samples/server/petstore/erlang-server/src/swagger_server.erl
@@ -9,6 +9,7 @@
 -spec child_spec( ID :: any(), #{
     ip            => inet:ip_address(),
     port          => inet:port_number(),
+    logic_handler => module(),
     net_opts      => []
 }) -> supervisor:child_spec().
 

--- a/samples/server/petstore/erlang-server/src/swagger_store_handler.erl
+++ b/samples/server/petstore/erlang-server/src/swagger_store_handler.erl
@@ -95,14 +95,6 @@ allowed_methods(Req, State) ->
         State :: state()
     }.
 
-is_authorized(
-    Req0,
-    State = #state{
-        operation_id = 'DeleteOrder' = OperationID,
-        logic_handler = LogicHandler
-    }
-) ->
-    {true, Req0, State};
 
 is_authorized(
     Req0,
@@ -124,26 +116,10 @@ is_authorized(
         {false, AuthHeader, Req} ->  {{false, AuthHeader}, Req, State}
     end;
 
-is_authorized(
-    Req0,
-    State = #state{
-        operation_id = 'GetOrderById' = OperationID,
-        logic_handler = LogicHandler
-    }
-) ->
-    {true, Req0, State};
 
-is_authorized(
-    Req0,
-    State = #state{
-        operation_id = 'PlaceOrder' = OperationID,
-        logic_handler = LogicHandler
-    }
-) ->
-    {true, Req0, State};
 
 is_authorized(Req, State) ->
-    {{false, <<"">>}, Req, State}.
+    {true, Req, State}.
 
 -spec content_types_accepted(Req :: cowboy_req:req(), State :: state()) ->
     {

--- a/samples/server/petstore/erlang-server/src/swagger_user_handler.erl
+++ b/samples/server/petstore/erlang-server/src/swagger_user_handler.erl
@@ -127,80 +127,16 @@ allowed_methods(Req, State) ->
         State :: state()
     }.
 
-is_authorized(
-    Req0,
-    State = #state{
-        operation_id = 'CreateUser' = OperationID,
-        logic_handler = LogicHandler
-    }
-) ->
-    {true, Req0, State};
 
-is_authorized(
-    Req0,
-    State = #state{
-        operation_id = 'CreateUsersWithArrayInput' = OperationID,
-        logic_handler = LogicHandler
-    }
-) ->
-    {true, Req0, State};
 
-is_authorized(
-    Req0,
-    State = #state{
-        operation_id = 'CreateUsersWithListInput' = OperationID,
-        logic_handler = LogicHandler
-    }
-) ->
-    {true, Req0, State};
 
-is_authorized(
-    Req0,
-    State = #state{
-        operation_id = 'DeleteUser' = OperationID,
-        logic_handler = LogicHandler
-    }
-) ->
-    {true, Req0, State};
 
-is_authorized(
-    Req0,
-    State = #state{
-        operation_id = 'GetUserByName' = OperationID,
-        logic_handler = LogicHandler
-    }
-) ->
-    {true, Req0, State};
 
-is_authorized(
-    Req0,
-    State = #state{
-        operation_id = 'LoginUser' = OperationID,
-        logic_handler = LogicHandler
-    }
-) ->
-    {true, Req0, State};
 
-is_authorized(
-    Req0,
-    State = #state{
-        operation_id = 'LogoutUser' = OperationID,
-        logic_handler = LogicHandler
-    }
-) ->
-    {true, Req0, State};
 
-is_authorized(
-    Req0,
-    State = #state{
-        operation_id = 'UpdateUser' = OperationID,
-        logic_handler = LogicHandler
-    }
-) ->
-    {true, Req0, State};
 
 is_authorized(Req, State) ->
-    {{false, <<"">>}, Req, State}.
+    {true, Req, State}.
 
 -spec content_types_accepted(Req :: cowboy_req:req(), State :: state()) ->
     {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
Resolves #6748 and #6749